### PR TITLE
chore: update package metadata

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,8 +2,8 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>muto_msgs</name>
-  <version>0.0.0</version>
-  <description>Eclipse Muto Messages Package</description>
+  <version>0.42.0</version>
+  <description>Eclipse Muto Messages - ROS 2 message and service definitions for inter-component communication including stack manifests, actions, commands, and plugin interfaces</description>
   <maintainer email="info@composiv.ai">Composiv</maintainer>
   <license>Eclipse Public License v2.0</license>
 


### PR DESCRIPTION
[eclipse-muto/#11](https://github.com/eclipse-muto/muto/issues/11)

- Unify version between setup.py and package.xml
- Decided 0.42.0 as the initial release
